### PR TITLE
Adding a new config property to allow override of batch names. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ module.exports = {
 
     // `appName` is your application name that will be shown in test results
     appName: undefined, // as default used your package name from package.json
-
+    // `batchName` is used as an identifier for your run in applitools.
+    // Unlike appName, this is not used to correlate individual tests
+    batchName: undefined, // when unset, it uses appName.
     // `viewportSize` is the required browser's viewport size or a list of sizes. It can be
     // an array of objects or a single object, e.g. {width: 800, height: 600}
     viewportSize: [

--- a/lib/DefaultConfig.js
+++ b/lib/DefaultConfig.js
@@ -9,6 +9,7 @@ module.exports = {
 
   // App & Test
   appName: process.env.APPLITOOLS_BATCH_NAME,
+  batchName: process.env.APPLITOOLS_BATCH_NAME,
   viewportSize: [
     { width: 800, height: 600 },
   ],

--- a/lib/EyesVisualGridRunner.js
+++ b/lib/EyesVisualGridRunner.js
@@ -115,7 +115,7 @@ class EyesVisualGridRunner {
     /** @type {object} */
     this._configs = configs;
 
-    this._testBatch = new BatchInfo(configs.appName);
+    this._testBatch = new BatchInfo(configs.batchName || process.env.APPLITOOLS_BATCH_NAME || configs.appName);
     this._rGridDom = new RGridDom();
     this._renderInfo = undefined;
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22014681/45787703-b885eb00-bcca-11e8-8349-b87c60d54ab3.png)

The problem that we're facing is wanting to rename the batches and have it be independent to the `appName`. This property set in the config file is used as both the key as well as the `batchName`. To my understanding, the `batchName` setting when creating `BatchInfo` is purely cosmetic so this PR overrides it when a property is set.

Feedback welcome as it's your project. I've also added some documentation. 